### PR TITLE
fix(docs): url on getting started page

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 This is the Trefle API documentation. The Trefle API aims to deliver all plants informations under an accessible interface.
 
-All API access is over HTTPS, and accessed from https://trefle.io. All data is sent and received as JSON.
+All API access is over HTTPS, and accessed from [https://trefle.io](https://trefle.io). All data is sent and received as JSON.
 
 ### What You Need
 


### PR DESCRIPTION
### Description
Update the url on the _GettingStarted_ page to accurately navigate the user.
Currently the url is appending the period (`<a href="https://trefle.io." ....`)

***

#### Changes
- [fix(docs): url on getting started page](https://github.com/treflehq/documentation/commit/b080658c32680b155f01f4e5b76074be01b31156)