### PR TITLE
Blog: announce the 2.0.2 release

### DIFF
--- a/blog/2026-09-04-2-0-2.md
+++ b/blog/2026-09-04-2-0-2.md
@@ -1,0 +1,39 @@
+---
+slug: 2-0-2-released
+title: "Trefle is back: 2.0.2"
+author: André Aubin
+author_title: Trefle Core Team
+author_url: https://twitter.com/lambda_2
+author_image_url: https://pbs.twimg.com/profile_images/1247213607353540608/i9oN_Gbg_400x400.jpg
+tags: [releases]
+---
+
+Trefle went quiet for a couple of years. It is back: the whole stack has been modernized and redeployed, and version 2.0.2 is now running in production.
+
+<!--truncate-->
+
+## What happened?
+
+The API you use every day was running on a codebase that had not moved since 2022. Over the past weeks it was brought up to date end to end, and today's release is the first visible result:
+
+- **Modern foundations**: Rails 8, Ruby 3.4, Sidekiq 7, Sentry 7. Every pull request now has to pass a 700-example test suite, a linter and a security scan before it can merge.
+- **Automated releases**: images are built and published by CI on every tagged release, so shipping improvements is no longer an event. Expect a steadier pace from now on.
+
+## What changed for API users?
+
+Nothing breaks, and a few things get better:
+
+- **Unknown parameters now fail loudly.** Typos in `filter`, `filter_not`, `order` or `range` keys used to be silently ignored, leaving you with unfiltered results and no clue why. They now return a `400` listing the valid keys.
+- **Rate-limit visibility.** Every `/api` response carries `RateLimit-Limit`, `RateLimit-Remaining` and `RateLimit-Reset` headers, so your client can pace itself instead of discovering the limit through a `429`.
+- **Fixed field**: `days_to_harvest` had been returning errors for a long time and has been removed from the payloads; `planting_days_to_harvest` is the authoritative field.
+- Authentication is unchanged: existing tokens and the JWT claim flow work exactly as before.
+
+## And for the website
+
+The [explore pages](https://trefle.io/explore) got a technical cleanup: real image tags with lazy loading and proper alt text, and about 6 MB of JavaScript removed from every page. More visible design work is queued up.
+
+## What's next
+
+The issue tracker is being worked through, oldest requests first: page size control, more filters, a proper CORS story for browser apps, and clarifying the data licensing so the dataset can be published as downloadable dumps. If one of those matters to you, the best way to help is to weigh in on the [existing issues](https://github.com/treflehq/trefle-api/issues).
+
+Thanks for having stuck around.


### PR DESCRIPTION
Release announcement for [v2.0.2](https://github.com/treflehq/trefle-api/releases/tag/v2.0.2): the modernization is deployed, what changed for API users, and what comes next.

Build verified locally (`yarn build` green, post renders in the blog index). Merging deploys it to docs.trefle.io automatically.