### PR TITLE
Docs: fix page size, curl bracket examples, and light list payloads

### DIFF
--- a/docs/advanced/plants-fields.md
+++ b/docs/advanced/plants-fields.md
@@ -9,6 +9,36 @@ When you query a species (or a plant), you will have a lot of fields to dig into
 This documentation is way lighter than the reference, and do not show all the fields. If you have any doubt, please check the [reference](/reference).
 :::
 
+## List responses only carry a subset of the fields
+
+Collection endpoints (`/api/v1/plants`, `/api/v1/species`, their `/search`
+variants, and nested lists such as `/api/v1/genus/:id/plants`) return a **light**
+version of each record, so a page of results stays small. Only these fields are
+included:
+
+`id`, `common_name`, `slug`, `scientific_name`, `year`, `bibliography`,
+`author`, `status`, `rank`, `family`, `family_common_name`, `genus`,
+`genus_id`, `image_url`, `synonyms`, `links`
+
+Every other field (`edible`, `edible_part`, `vegetable`, `duration`,
+`observations`, `common_names`, `distribution`, `growth`, `specifications`,
+`images`, `sources`…) is only present on the detail endpoints, one record at a
+time:
+
+```bash
+# a list: light payload, no `edible` field
+curl -g 'https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[edible]=true'
+
+# one record: full payload, `edible` included
+curl 'https://trefle.io/api/v1/plants/beach-strawberry?token=YOUR_TREFLE_TOKEN'
+```
+
+:::note You can still filter and sort on the missing fields
+Filtering, ordering and ranges are applied in the database, not on the
+serialized response. `filter[edible]=true` works on a list even though `edible`
+is not part of that list's payload. Follow the record's `links.self` to read
+the value back.
+:::
 
 ## Species
 

--- a/docs/advanced/plants-fields.md
+++ b/docs/advanced/plants-fields.md
@@ -13,31 +13,35 @@ This documentation is way lighter than the reference, and do not show all the fi
 
 Collection endpoints (`/api/v1/plants`, `/api/v1/species`, their `/search`
 variants, and nested lists such as `/api/v1/genus/:id/plants`) return a **light**
-version of each record, so a page of results stays small. Only these fields are
-included:
+version of each record, so a page of results stays small. The two lists don't
+carry exactly the same subset:
 
-`id`, `common_name`, `slug`, `scientific_name`, `year`, `bibliography`,
-`author`, `status`, `rank`, `family`, `family_common_name`, `genus`,
-`genus_id`, `image_url`, `synonyms`, `links`
+- **Species lists**: `id`, `common_name`, `slug`, `scientific_name`, `year`,
+  `bibliography`, `author`, `status`, `rank`, `family`, `family_common_name`,
+  `genus`, `genus_id`, `image_url`, `synonyms`, `links`
+- **Plants lists**: `id`, `common_name`, `slug`, `scientific_name`, `year`,
+  `bibliography`, `author`, `family_common_name`, `genus_id`,
+  `main_species_id`, `vegetable`, `observations`, `image_url`, `links`
 
-Every other field (`edible`, `edible_part`, `vegetable`, `duration`,
-`observations`, `common_names`, `distribution`, `growth`, `specifications`,
-`images`, `sources`…) is only present on the detail endpoints, one record at a
-time:
+Every other field (`edible`, `edible_part`, `duration`, `common_names`,
+`distribution`, `growth`, `specifications`, `images`, `sources`…) is only
+present on the detail endpoints, one record at a time:
 
 ```bash
 # a list: light payload, no `edible` field
-curl -g 'https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[edible]=true'
+curl -g 'https://trefle.io/api/v1/species?token=YOUR_TREFLE_TOKEN&filter[edible]=true'
 
 # one record: full payload, `edible` included
-curl 'https://trefle.io/api/v1/plants/beach-strawberry?token=YOUR_TREFLE_TOKEN'
+curl 'https://trefle.io/api/v1/species/fragaria-chiloensis?token=YOUR_TREFLE_TOKEN'
 ```
 
 :::note You can still filter and sort on the missing fields
 Filtering, ordering and ranges are applied in the database, not on the
-serialized response. `filter[edible]=true` works on a list even though `edible`
-is not part of that list's payload. Follow the record's `links.self` to read
-the value back.
+serialized response. `filter[edible]=true` works on a species list even though
+`edible` is not part of that list's payload. Follow the record's `links.self`
+to read the value back. Each endpoint validates its own filter keys (an unknown
+key returns a `400` listing the valid ones), so a filter accepted by `/species`
+is not necessarily accepted by `/plants`.
 :::
 
 ## Species

--- a/docs/guides/filtering.md
+++ b/docs/guides/filtering.md
@@ -20,7 +20,7 @@ We can filter on one or several values, with the `filter[FIELD]=value1,value2,va
 :::
 
 :::note The field you filter on may not be in the response
-Lists return a light version of each record, so `filter[edible]=true` works even
+Lists return a light version of each record, so `filter[edible]=true` works on `/species` even
 though `edible` is not part of the list payload. See
 [List responses only carry a subset of the fields](/docs/advanced/plants-fields#list-responses-only-carry-a-subset-of-the-fields).
 :::

--- a/docs/guides/filtering.md
+++ b/docs/guides/filtering.md
@@ -12,6 +12,13 @@ As you may have seen, there is a lot of plants here. In order to find what you'r
 We can filter on one or several values, with the `filter[FIELD]=value1,value2,value3...` parameter, or on a range of values, with the `range[FIELD]=min,max` parameter.
 :::
 
+:::caution Using curl? Add the `-g` flag
+`curl` treats `[` and `]` as globbing characters and fails with
+`curl: (3) bad range in URL position` on any `filter[…]`, `range[…]` or
+`order[…]` parameter. Quoting the URL does not help: pass `-g` (or
+`--globoff`) to turn globbing off, as in the examples below.
+:::
+
 ### Filter on a single value
 
 Let's query only plants with the "Beach Strawberry" common name:.
@@ -40,7 +47,7 @@ Open your browser and navigate to
 In your terminal:
 
 ```bash
-curl 'https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[common_name]=beach%20strawberry'
+curl -g 'https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[common_name]=beach%20strawberry'
 ```
 
 </TabItem>
@@ -140,7 +147,7 @@ Open your browser and navigate to
 In your terminal:
 
 ```bash
-curl 'https://trefle.io/api/v1/species?token=YOUR_TREFLE_TOKEN&filter[edible_part]=roots,leaves'
+curl -g 'https://trefle.io/api/v1/species?token=YOUR_TREFLE_TOKEN&filter[edible_part]=roots,leaves'
 ```
 
 </TabItem>
@@ -285,7 +292,7 @@ Open your browser and navigate to
 In your terminal:
 
 ```bash
-curl 'https://trefle.io/api/v1/species?token=YOUR_TREFLE_TOKEN&range[maximum_height_cm]=5,20'
+curl -g 'https://trefle.io/api/v1/species?token=YOUR_TREFLE_TOKEN&range[maximum_height_cm]=5,20'
 ```
 
 </TabItem>

--- a/docs/guides/filtering.md
+++ b/docs/guides/filtering.md
@@ -19,6 +19,12 @@ We can filter on one or several values, with the `filter[FIELD]=value1,value2,va
 `--globoff`) to turn globbing off, as in the examples below.
 :::
 
+:::note The field you filter on may not be in the response
+Lists return a light version of each record, so `filter[edible]=true` works even
+though `edible` is not part of the list payload. See
+[List responses only carry a subset of the fields](/docs/advanced/plants-fields#list-responses-only-carry-a-subset-of-the-fields).
+:::
+
 ### Filter on a single value
 
 Let's query only plants with the "Beach Strawberry" common name:.

--- a/docs/guides/pagination.md
+++ b/docs/guides/pagination.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-When you query a collection (ex: `/api/v1/plants`), you'll notice that you have only 30 items returned.
+When you query a collection (ex: `/api/v1/plants`), you'll notice that you have only 20 items returned.
 
 That's because results are paginated. You have links for the next page in the `links` attribute of the JSON response.
 
@@ -107,7 +107,7 @@ You now got the second page of the plants.
                 "Altensteinia rosei"
             ],
             "year": 1922
-        },  // ... 28 more items
+        },  // ... 18 more items
     ],
     "links": {
         "first": "/api/v1/species?page=1",
@@ -119,4 +119,16 @@ You now got the second page of the plants.
     "meta": {
         "total": 417293
     }}
+```
+
+## Changing the page size
+
+Collection endpoints such as `/api/v1/plants` and `/api/v1/species` always return
+20 items per page. The page size is fixed and there is no parameter to change it.
+
+The search endpoints are the exception: `/api/v1/plants/search` and
+`/api/v1/species/search` accept a `limit` parameter, which also defaults to 20.
+
+```bash
+curl -g 'https://trefle.io/api/v1/plants/search?token=YOUR_TREFLE_TOKEN&q=coconut&limit=5'
 ```

--- a/docs/guides/sorting.md
+++ b/docs/guides/sorting.md
@@ -13,6 +13,13 @@ Sometimes, we also need to specify a particular order for sorting the results.
 You can order results by a specific value with the `order[FIELD]=asc|desc...` parameter.
 :::
 
+:::caution Using curl? Add the `-g` flag
+`curl` treats `[` and `]` as globbing characters and fails with
+`curl: (3) bad range in URL position` on any `filter[…]`, `range[…]` or
+`order[…]` parameter. Quoting the URL does not help: pass `-g` (or
+`--globoff`) to turn globbing off, as in the examples below.
+:::
+
 ### Basic sorting
 
 Let's sort plants by year, in a **ascending** order:
@@ -41,7 +48,7 @@ Open your browser and navigate to
 In your terminal:
 
 ```bash
-curl 'https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&order[year]=asc'
+curl -g 'https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&order[year]=asc'
 ```
 
 </TabItem>
@@ -122,7 +129,7 @@ For example, if we want to get the tallest trees, we will have trees with `null`
 # Get all plants
 # -> with tree ligneous type (filter[ligneous_type]=tree)
 # -> ordered by maximum height descending (highest first) (order[maximum_height_cm]=desc)
-curl "https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[ligneous_type]=tree&order[maximum_height_cm]=desc"
+curl -g "https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[ligneous_type]=tree&order[maximum_height_cm]=desc"
 ```
 
 To avoid that, you can exclude null values ([see Filtering](filtering#exclude-null-values)):
@@ -132,7 +139,7 @@ To avoid that, you can exclude null values ([see Filtering](filtering#exclude-nu
 # -> with tree ligneous type (filter[ligneous_type]=tree)
 # -> ordered by maximum height descending (highest first) (order[maximum_height_cm]=desc)
 # -> and without plants having a null maximum height (filter_not[maximum_height_cm]=null)
-curl "https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[ligneous_type]=tree&order[maximum_height_cm]=desc&&filter_not[maximum_height_cm]=null"
+curl -g "https://trefle.io/api/v1/plants?token=YOUR_TREFLE_TOKEN&filter[ligneous_type]=tree&order[maximum_height_cm]=desc&&filter_not[maximum_height_cm]=null"
 ```
 
 


### PR DESCRIPTION
Three documentation bugs reported by API users, all verified against the current
API code before writing.

### Closes #14 — collections return 20 items per page, not 30

`config/initializers/pagy.rb` never overrides `items`, and no controller passes
one to `pagy()`, so every collection endpoint serves the Pagy default of 20. The
reporter's arithmetic confirms it: 377570 results with `links.last=18879` is
20 per page, not 30. The sample response already on the page is consistent with
20 too (417293 / 20 = 20865, the `last` link it shows).

Fixed the figure and the `// ... 28 more items` comment, and documented the
`limit` parameter, which was undocumented: `/plants/search` and
`/species/search` accept it, other collection endpoints do not.

### Closes #10 — curl fails on bracketed query parameters

`curl` treats `[` and `]` as globbing characters, so `filter[…]`, `range[…]` and
`order[…]` examples fail with `curl: (3) bad range in URL position`. Quoting the
URL does not help. Added `-g` to the six affected examples and an explanation
where the bracket syntax is introduced in each guide.

### Closes #18 — filterable fields missing from list responses

Collection endpoints serialize with `SpeciesLightSerializer`, detail endpoints
with the full `SpeciesSerializer`/`PlantSerializer`. So `filter[edible]=true`
works while `edible` is absent from the response, which reads as a bug. Added a
section to the plants fields page listing exactly what a collection carries,
pointing at the detail endpoints for the rest, and noting that filters run in
the database rather than on the serialized payload. Cross-referenced from the
filtering guide.

### Verification

`yarn build` passes. The site runs `onBrokenLinks: 'throw'`, so the new
cross-reference is checked; I also confirmed the target anchor id in the built
HTML, since Docusaurus 2 does not validate anchors. Rendered output checked for
all three fixes.

Touches: docs/advanced, docs/guides
