### PR TITLE
Blog: announce the 2.1.0 release

### DIFF
--- a/blog/2026-09-04-2-1-0.md
+++ b/blog/2026-09-04-2-1-0.md
@@ -1,0 +1,38 @@
+---
+slug: 2-1-0-released
+title: "2.1.0: CORS, and where the data comes from"
+author: André Aubin
+author_title: Trefle Core Team
+author_url: https://twitter.com/lambda_2
+author_image_url: https://pbs.twimg.com/profile_images/1247213607353540608/i9oN_Gbg_400x400.jpg
+tags: [releases]
+---
+
+Version 2.1.0 is in production. It delivers the most requested feature in Trefle's history — CORS — and starts a longer journey: making every value in the database traceable to its source.
+
+<!--truncate-->
+
+## CORS is enabled
+
+You can now call the API directly from a browser. No more proxy backend just to forward requests: grab a token, `fetch` from your frontend, done. This closes the oldest open request on the tracker ([#91](https://github.com/treflehq/trefle-api/issues/91), and more recently [#211](https://github.com/treflehq/trefle-api/issues/211)).
+
+The usual caveat applies: a token shipped in client-side code is visible to anyone who opens the developer tools. For public demos and prototypes that trade-off is often fine; for production apps, keep quota-sensitive usage behind your own backend.
+
+## Where does that number come from?
+
+Trefle aggregates botanical data from many sources — GBIF, POWO, the USDA, Baseflor, Wikipedia and others. Historically, when two sources disagreed, the last one crawled silently won. That is not good enough for a dataset people build real applications on, so 2.1.0 lays new foundations:
+
+- **Provenance is now recorded.** Every value ingested from now on is stored as a *fact*: which source claims it, what the value is, and how it was established. A new endpoint exposes the trail: `GET /api/v1/species/{id}/facts`. It starts mostly empty and fills up as the pipeline runs.
+- **Sources are ranked.** A curated botanical database can no longer be overwritten by a Wikipedia infobox. When sources disagree, the strongest one wins the displayed value — and the disagreement stays visible instead of being erased.
+- **Implausible values are rejected.** A plant that is 10 km tall or a pH of 47 now gets refused at ingestion and flagged for review, and inconsistencies like `ph_minimum > ph_maximum` are hunted continuously by the hourly data checks.
+- **The completion score is honest now.** The old one counted internal bookkeeping columns and treated legitimate zeros as missing data. The new one measures actual botanical fields, and only those that make sense for the species — a wild oak is no longer "incomplete" for lacking a sowing guide.
+
+One bug fix worth calling out: on plant payloads, the `hybrids` and `subvarieties` lists had been swapped — each was served under the other's key. If your app reads either field, the data is now correct.
+
+Everything in this release is additive: no existing payload changed shape, and authentication is unchanged.
+
+## What's next
+
+The provenance system is the groundwork for the actual goal: filling the gaps. Most species in the database have well-documented names but sparse traits, and we can now measure exactly where the gaps are and fill them with sourced, verifiable values — starting with the species you actually look up. Alongside that, the earlier promises still stand: client-controlled page size, more filters, and downloadable dumps once licensing is clarified.
+
+As always, the [issue tracker](https://github.com/treflehq/trefle-api/issues) is the best place to tell us what matters to you.


### PR DESCRIPTION
Release post for v2.1.0: CORS enabled on the public API, the new provenance system (`/species/{id}/facts`, source ranking, plausibility checks, honest completion score) and the hybrids/subvarieties fix.

Follows up on the 2.0.2 post (its "proper CORS story" promise is delivered here). Build verified locally (`yarn build` green, page generated at `blog/2-1-0-released`).

Merging publishes the post (auto-deploy on master).